### PR TITLE
Add Claude Code playwright plugin configuration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "playwright@claude-plugins-official": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ web-build/
 
 # @end expo-cli
 
-settings.json
+# settings.json  # commented out to allow .claude/settings.json to be checked in
 
 # Local configuration
 .localconf.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+### Change management
+
+For every change, use a new graphite branch branched of the latest in the workspace. We can later merge/organize them into more coherent PRs.
+
+### Automated UI Testing with Playwright MCP
+
+**ALWAYS use Playwright MCP to verify UI changes before committing.** This ensures changes work correctly and provides visual documentation.
+
+Add instructions here for usage after figuring out how to best use playwright.


### PR DESCRIPTION
## Summary
- Comment out `settings.json` in `.gitignore` to allow `.claude/settings.json` to be tracked
- Add `.claude/settings.json` with playwright plugin enabled for the project
- Add `CLAUDE.md` with project instructions for change management and Playwright testing guidelines

This allows all team members to automatically have the playwright plugin available when using Claude Code on this repo.

## Test plan
- [ ] Clone repo fresh and verify `.claude/settings.json` is present
- [ ] Run Claude Code and verify playwright plugin is available
- [ ] Verify CLAUDE.md instructions are visible to Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)