### PR TITLE
Disable Firebase reCAPTCHA for test phone numbers in local dev

### DIFF
--- a/client/AuthConfig.tsx
+++ b/client/AuthConfig.tsx
@@ -6,9 +6,29 @@ import {useOnAllowlist} from '@toolkit/core/util/Access';
 import {CodedError} from '@toolkit/core/util/CodedError';
 import {FirebaseAuthService} from '@toolkit/providers/firebase/client/AuthService';
 import firebase from 'firebase';
+import 'firebase/auth';
 import React from 'react';
 
+// Track if we've configured auth settings for testing
+let authTestConfigured = false;
+
+function configureAuthForTesting() {
+  // Only disable reCAPTCHA in local development with E2E_TEST flag
+  const isLocalDev =
+    typeof window !== 'undefined' &&
+    (window.location.hostname === 'localhost' ||
+      window.location.hostname === '127.0.0.1');
+
+  if (!authTestConfigured && process.env.E2E_TEST === 'true' && isLocalDev) {
+    // @ts-ignore - appVerificationDisabledForTesting exists on auth settings
+    firebase.auth().settings.appVerificationDisabledForTesting = true;
+    authTestConfigured = true;
+  }
+}
+
 export default function AuthConfig(props: {children?: React.ReactNode}) {
+  // Configure auth for testing after Firebase is initialized
+  configureAuthForTesting();
   const getUser = useApi(GetUser);
   const getOnAllowlist = useOnAllowlist();
 

--- a/project/webpack.config.js
+++ b/project/webpack.config.js
@@ -39,6 +39,13 @@ module.exports = async function (env, argv) {
   WebpackUtils.unoptimize(config);
   WebpackUtils.quitAfterBuild(config); // Expo CLI wasn't terminating after builds
 
+  // Pass E2E_TEST env var to client code for disabling Firebase reCAPTCHA in tests
+  config.plugins.push(
+    new webpack.DefinePlugin({
+      'process.env.E2E_TEST': JSON.stringify(process.env.E2E_TEST || 'false'),
+    })
+  );
+
   config.resolve.alias['react-native-webview'] = 'react-native-web-webview';
 
   // expo-firebase-recaptcha uses firebase v9 APIs in v8 interop mode


### PR DESCRIPTION
## Summary
- Adds E2E_TEST environment variable passthrough in webpack config
- Disables Firebase reCAPTCHA verification only when BOTH conditions are met:
  - E2E_TEST=true is set
  - Running on localhost or 127.0.0.1
- Enables automated testing with Firebase test phone numbers

## Usage
```bash
E2E_TEST=true yarn web
```

Then use test phone number +14155555555 with code 555555

## Test plan
- [ ] Verify reCAPTCHA is bypassed in local dev with E2E_TEST=true
- [ ] Verify reCAPTCHA is still enabled in production
- [ ] Verify reCAPTCHA is still enabled in local dev without E2E_TEST

🤖 Generated with [Claude Code](https://claude.com/claude-code)